### PR TITLE
Remove duplicate login form block

### DIFF
--- a/a1a2vocab.py
+++ b/a1a2vocab.py
@@ -108,23 +108,6 @@ def auth_screen():
             st.session_state["role"] = memberships[0]["role"]
             st.rerun()
 
-    with tab_login:
-        email_l = st.text_input("Email", key="login_email")
-        pw_l = st.text_input("Password", type="password", key="login_pw")
-        if st.button("Log in", type="primary", use_container_width=True):
-            sess = sb.auth.sign_in_with_password({"email": email_l, "password": pw_l})
-            if sess.user:
-                st.session_state["user"] = {"id": sess.user.id, "email": email_l}
-                memberships = get_user_orgs(sess.user.id)
-                if not memberships:
-                    st.warning("No organization yet. Use 'Create store' first.")
-                    st.stop()
-                st.session_state["org_id"] = memberships[0]["org_id"]
-                st.session_state["role"] = memberships[0]["role"]
-                st.rerun()
-            else:
-                st.error("Invalid email or password.")
-
 # -------------------------------
 # Data access (Supabase)
 # -------------------------------


### PR DESCRIPTION
## Summary
- remove the second tab_login block so only one login form uses the login_email/login_pw keys
- prevent duplicate element key errors triggered by the redundant login UI

## Testing
- unable to run `streamlit run a1a2vocab.py` (missing streamlit package in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1894e6bec832184d5db81f4d7e41e