### PR TITLE
Automate sitemap lastmod values from git history

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "version": "1.0.0",
   "description": "Static Sedifex developer docs site",
   "scripts": {
-    "build": "rm -rf public && mkdir -p public && cp -r *.html *.css *.txt *.xml public/ && echo 'Static site ready for Vercel (output: public/)'",
+    "build": "npm run generate-sitemap && rm -rf public && mkdir -p public && cp -r *.html *.css *.txt *.xml public/ && echo 'Static site ready for Vercel (output: public/)'",
     "vercel-build": "npm run build",
-    "start": "npx serve . -l 3000"
+    "start": "npx serve . -l 3000",
+    "generate-sitemap": "node scripts/generate-sitemap.mjs"
   },
   "devDependencies": {
     "serve": "^14.2.3"

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,0 +1,45 @@
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const SITEMAP_PATH = 'sitemap.xml';
+const SITE_ORIGIN = 'https://developer.sedifex.com';
+
+function getGitLastModifiedDate(filePath) {
+  try {
+    return execSync(`git log -1 --format=%cs -- ${JSON.stringify(filePath)}`, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function resolveFilePathFromLoc(loc) {
+  const url = new URL(loc);
+  const relativePath = url.pathname === '/' ? 'index.html' : url.pathname.slice(1);
+  return path.normalize(relativePath);
+}
+
+const input = readFileSync(SITEMAP_PATH, 'utf8');
+const updated = input.replace(/<url>([\s\S]*?)<\/url>/g, (block) => {
+  const locMatch = block.match(/<loc>([^<]+)<\/loc>/);
+  if (!locMatch) return block;
+
+  const loc = locMatch[1].trim();
+  if (!loc.startsWith(SITE_ORIGIN)) return block;
+
+  const targetFile = resolveFilePathFromLoc(loc);
+  const lastmod = getGitLastModifiedDate(targetFile);
+  if (!lastmod) return block;
+
+  if (/<lastmod>[^<]*<\/lastmod>/.test(block)) {
+    return block.replace(/<lastmod>[^<]*<\/lastmod>/, `<lastmod>${lastmod}</lastmod>`);
+  }
+
+  return block.replace(/<loc>[^<]+<\/loc>/, `$&\n    <lastmod>${lastmod}</lastmod>`);
+});
+
+writeFileSync(SITEMAP_PATH, updated);
+console.log('Updated sitemap.xml lastmod values from git history.');

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://developer.sedifex.com/</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://developer.sedifex.com/quickstart.html</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://developer.sedifex.com/api-reference.html</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://developer.sedifex.com/webhooks.html</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://developer.sedifex.com/guides.html</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -38,7 +38,7 @@
   </url>
   <url>
     <loc>https://developer.sedifex.com/troubleshooting.html</loc>
-    <lastmod>2026-04-04</lastmod>
+    <lastmod>2026-04-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>


### PR DESCRIPTION
### Motivation
- The `sitemap.xml` contained hardcoded and inconsistent `<lastmod>` dates that can become stale quickly.
- Make sitemap `lastmod` authoritative by deriving dates from actual file modification history in git.
- Ensure sitemap is refreshed automatically as part of the site build so deployed artifacts stay accurate.

### Description
- Add `scripts/generate-sitemap.mjs` which parses `sitemap.xml`, maps each `<loc>` to a local file (`/` → `index.html`), and uses `git log -1 --format=%cs -- <file>` to compute and insert or replace the `<lastmod>` value.
- Add a `generate-sitemap` npm script and prepend `npm run generate-sitemap` to the `build` script in `package.json` so sitemap dates are updated during `npm run build`.
- Regenerate `sitemap.xml` so existing entries now reflect per-file git commit dates; changes committed alongside the new script.

### Testing
- Ran `npm run generate-sitemap` and the script completed successfully and updated `sitemap.xml`.
- Ran `npm run build` which executes `generate-sitemap` first and completed successfully (site artifacts copied to `public/`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a044c9d65788321b0720f2848f14fc5)