### PR TITLE
Add Vercel rewrites for /integration-api-guide route

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,5 +12,15 @@
         }
       ]
     }
+  ],
+  "rewrites": [
+    {
+      "source": "/integration-api-guide",
+      "destination": "/integration-api-guide.md"
+    },
+    {
+      "source": "/integration-api-guide/",
+      "destination": "/integration-api-guide.md"
+    }
   ]
 }


### PR DESCRIPTION
### Motivation
- Ensure the Integration API guide is reachable at a clean URL by mapping `/integration-api-guide` and `/integration-api-guide/` to the existing markdown file when `cleanUrls` is enabled.

### Description
- Add a `rewrites` section to `vercel.json` that maps `"/integration-api-guide"` and `"/integration-api-guide/"` to `"/integration-api-guide.md"`.

### Testing
- Validated the JSON structure by loading and re-serializing `vercel.json` with a Python script, which succeeded.
- Verified the `rewrites` entries are present in `vercel.json` and that only `vercel.json` was modified, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04654b5d2c83218b57374a247a2a9d)