### PR TITLE
Add static documentation pages and improve build script

### DIFF
--- a/how-to-use-sedifex.html
+++ b/how-to-use-sedifex.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>How to Use Sedifex</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>How to Use Sedifex</h1>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="how-to-use-sedifex.html">Navigation Guide</a>
+      <a href="integration-api-guide.html">Integration API Guide</a>
+    </nav>
+  </header>
+
+  <main>
+    <h2>Current Navigation Guide</h2>
+    <p>Sedifex is a POS and operations platform for retail and service businesses.</p>
+
+    <h3>Owner navigation</h3>
+    <ul>
+      <li>Dashboard</li><li>Items</li><li>Sell</li><li>Customers</li><li>Bookings</li>
+      <li>Blog</li><li>SMS</li><li>Bulk email</li><li>Business records</li><li>Public page</li><li>Account</li>
+    </ul>
+
+    <h3>Staff navigation</h3>
+    <ul>
+      <li>Sell</li><li>Customers</li><li>Bookings</li><li>Blog</li><li>Business records</li>
+    </ul>
+
+    <p>For the complete step-by-step operating guide, view the source markdown: <a href="how-to-use-sedifex.md">how-to-use-sedifex.md</a>.</p>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sedifex Docs</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Sedifex Developer Documentation</h1>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="how-to-use-sedifex.html">Navigation Guide</a>
+      <a href="integration-api-guide.html">Integration API Guide</a>
+    </nav>
+  </header>
+
+  <main>
+    <section>
+      <h2>Start here</h2>
+      <p>Use the guides below to get up and running quickly.</p>
+      <ul>
+        <li><a href="how-to-use-sedifex.html">How to Use Sedifex</a> — app navigation and core workflows.</li>
+        <li><a href="integration-api-guide.html">Integration API Guide (v1)</a> — authentication, contract headers, and endpoint behavior.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/integration-api-guide.html
+++ b/integration-api-guide.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sedifex Integration API Guide</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Sedifex Integration API Guide (v1)</h1>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="how-to-use-sedifex.html">Navigation Guide</a>
+      <a href="integration-api-guide.html">Integration API Guide</a>
+    </nav>
+  </header>
+
+  <main>
+    <h2>Authentication and API keys</h2>
+    <p>Set integration credentials server-side and send <code>x-api-key</code> and <code>X-Sedifex-Contract-Version</code> headers on authenticated calls.</p>
+
+    <h2>Contract version</h2>
+    <p>Current contract version: <strong>2026-04-13</strong>.</p>
+
+    <h2>Endpoint behavior</h2>
+    <p><code>GET /v1/products</code> supports sorting, paging, and per-store balancing (with <code>maxPerStore</code>).</p>
+
+    <p>For full API details and response examples, view <a href="integration-api-guide.md">integration-api-guide.md</a>.</p>
+  </main>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "Static Sedifex developer docs site",
   "scripts": {
-    "build": "npm run generate-sitemap && rm -rf public && mkdir -p public && cp -r *.html *.css *.txt *.xml public/ && echo 'Static site ready for Vercel (output: public/)'",
+    "build": "npm run generate-sitemap && rm -rf public && mkdir -p public && find . -maxdepth 1 -type f \\( -name '*.html' -o -name '*.css' -o -name '*.txt' -o -name '*.xml' -o -name '*.php' \\) -exec cp {} public/ \\; && echo 'Static site ready for Vercel (output: public/)'",
     "vercel-build": "npm run build",
     "start": "npx serve . -l 3000",
     "generate-sitemap": "node scripts/generate-sitemap.mjs"


### PR DESCRIPTION
### Motivation

- Provide a minimal static developer docs site for Sedifex with navigation and API reference pages.
- Make the build step more robust when collecting site assets for Vercel by supporting a wider set of file types and avoiding brittle `cp` usage.

### Description

- Add `index.html`, `how-to-use-sedifex.html`, and `integration-api-guide.html` as new static documentation pages. 
- Update `package.json` `build` script to run `generate-sitemap` and then use `find` to copy files matching `*.html`, `*.css`, `*.txt`, `*.xml`, and `*.php` into the `public/` directory before finishing the build. 
- Preserve `vercel-build`, `start`, and `generate-sitemap` script entries and keep `serve` as a dev dependency.

### Testing

- Ran `npm run generate-sitemap` successfully as part of the build preparation. 
- Ran `npm run build` which executed the sitemap generation and the updated copy step and produced the `public/` output successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a046db87cb88321960d1b4ee59bb50b)