### PR TITLE
Fix malformed package.json by removing unresolved merge conflict markers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-<<<<<<< HEAD
   "name": "sedifex-developers",
   "version": "0.1.0",
   "private": true,
@@ -28,19 +27,5 @@
     "eslint-config-next": "16.2.6",
     "tailwindcss": "^4",
     "typescript": "^5"
-=======
-  "name": "sedifex-stores-docs",
-  "private": true,
-  "version": "1.0.0",
-  "description": "Static Sedifex developer docs site",
-  "scripts": {
-    "build": "npm run generate-sitemap && rm -rf public && mkdir -p public && find . -maxdepth 1 -type f \\( -name '*.html' -o -name '*.css' -o -name '*.txt' -o -name '*.xml' -o -name '*.php' \\) -exec cp {} public/ \\; && echo 'Static site ready for Vercel (output: public/)'",
-    "vercel-build": "npm run build",
-    "start": "npx serve . -l 3000",
-    "generate-sitemap": "node scripts/generate-sitemap.mjs"
-  },
-  "devDependencies": {
-    "serve": "^14.2.3"
->>>>>>> ab77effc4fc4f4fdf7ec43e4d90e6c010c5c6140
   }
 }


### PR DESCRIPTION
### Motivation
- Restore a valid `package.json` manifest after unresolved Git merge conflict markers caused a JSON parse error and prevented the project from being parsed/deployed.

### Description
- Removed the merge conflict markers and kept the `sedifex-developers` JSON manifest with the existing Next.js scripts and dependencies in `package.json` to produce valid JSON.

### Testing
- Ran `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` which succeeded and confirmed the manifest is valid JSON.
- Ran `npm run lint`, which failed in this environment because the `eslint` package is not installed locally despite being declared in `devDependencies`, so linting could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04acb102348321ae039208ace3b3c4)