### PR TITLE
Fix frontmatter typing in docs parser

### DIFF
--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -92,7 +92,7 @@ function readDoc(relativeFilePath: string): DocRecord {
   const extension = path.extname(relativeFilePath).toLowerCase();
   const isMarkdown = extension === ".md" || extension === ".mdx";
 
-  const parsed = isMarkdown
+  const parsed: { data: Record<string, unknown>; content: string } = isMarkdown
     ? matter(raw)
     : {
         data: {},


### PR DESCRIPTION
### Motivation
- Fix a TypeScript narrowing error so accessing `parsed.data.title` and `parsed.data.description` is safe even when the file is not markdown.

### Description
- Add an explicit type annotation `const parsed: { data: Record<string, unknown>; content: string } = ...` in `src/lib/docs.ts` so `parsed.data` is not inferred as `{}` for non-markdown files and the existing title/description logic is preserved.

### Testing
- Ran `npm run build`, which attempted a build but failed in this environment with `sh: 1: next: not found` (no further automated tests were run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ece89f4483218d259e98ef1e9359)